### PR TITLE
update android kotlin_version to 1.2.71

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'de.gigadroid.flutterudid'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.71'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
update android kotlin_version to 1.2.71 to avoid issue : "The Android Gradle plugin supports only Kotlin Gradle plugin version 1.2.51 and higher. Project 'flutter_udid' is using version 1.2.30."