### PR TITLE
chore: fix typo in package description (`across`)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_udid
-description: Plugin to retrieve a persistent UDID accross reinstalls on iOS and Android
+description: Plugin to retrieve a persistent UDID across reinstalls on iOS and Android
 version: 2.0.0
 homepage: https://github.com/GigaDroid/flutter_udid
 


### PR DESCRIPTION
I think it should be `across` instead of `accross` 😅