### PR TITLE
fix: linux permission denied, use /etc/machine-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+* Linux use machine Id
+
 ## 3.0.0
 * Add Windows and Linux support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 4.0.0
+* BREAKING: Linux will always use the id located at /etc/machine-id now, and not use the BIOS UUID due to permission issues
+
 ## 3.0.1
-* Linux use machine Id
+* Upgrade Gradle to 8.12, Android Gradle Plugin to 8.3, Kotlin version to 1.8.22 and Java version to 11
 
 ## 3.0.0
 * Add Windows and Linux support

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ String udid = await FlutterUdid.udid;
 
 This provides an UDID using the format of the corresponding platform.
 
-| Platform | Format                                 | Source                                                                                                                                      |
-|----------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| Platform | Format                                 | Source                                                                                                                                          |
+|----------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | iOS      | `7946DA4E-8429-423C-B405-B3FC77914E3E` | [identifierForVendor (saved to Keychain for persistence)](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) |
-| Android  | `8af8770a27cfd182`                     | [Settings.Secure.ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)                           |
-| Mac      | `707E990C-D002-520B-ABA6-4216C6D514BF` | [kIOPlatformUUIDKey](https://developer.apple.com/documentation/iokit/kioplatformuuidkey)                                                    |
-| Windows  | `99A4D301-53F5-11CB-8CA0-9CA39A9E1F01` | BIOS UUID                                                                                                                                   |
-| Linux    | `1124435e065241dcae2241e9caab9a6c` | Machine Id                                                                                                                                    |
+| Android  | `8af8770a27cfd182`                     | [Settings.Secure.ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)                               |
+| Mac      | `707E990C-D002-520B-ABA6-4216C6D514BF` | [kIOPlatformUUIDKey](https://developer.apple.com/documentation/iokit/kioplatformuuidkey)                                                        |
+| Windows  | `99A4D301-53F5-11CB-8CA0-9CA39A9E1F01` | BIOS UUID                                                                                                                                       |
+| Linux    | `1124435e065241dcae2241e9caab9a6c` | Machine ID                                                                                                                                      |
 
 To get a consistent formatting on all platforms use:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This provides an UDID using the format of the corresponding platform.
 | Android  | `8af8770a27cfd182`                     | [Settings.Secure.ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)                           |
 | Mac      | `707E990C-D002-520B-ABA6-4216C6D514BF` | [kIOPlatformUUIDKey](https://developer.apple.com/documentation/iokit/kioplatformuuidkey)                                                    |
 | Windows  | `99A4D301-53F5-11CB-8CA0-9CA39A9E1F01` | BIOS UUID                                                                                                                                   |
-| Linux    | `32a70060-2a39-437e-88e2-d68e6154de9f` | BIOS UUID                                                                                                                                   |
+| Linux    | `1124435e065241dcae2241e9caab9a6c` | Machine Id                                                                                                                                    |
 
 To get a consistent formatting on all platforms use:
 

--- a/linux/flutter_udid_plugin.cc
+++ b/linux/flutter_udid_plugin.cc
@@ -25,16 +25,9 @@ static void flutter_udid_plugin_handle_method_call(
   g_autoptr(FlMethodResponse) response = nullptr;
 
   const gchar* method = fl_method_call_get_name(method_call);
-  // Inspired from: https://github.com/BestBurning/platform_device_id
   if (strcmp(method, "getUDID") == 0) {
     FILE *rstream = NULL;
     char buf[1024] = {0};
-    /*
-    // fix: linux permission denied, use /etc/machine-id
-    rstream = popen("dmidecode -s system-uuid","r");
-    fread(buf, sizeof(char), sizeof(buf), rstream);
-    pclose(rstream);
-    */
     if(buf[0] == 0) {
       rstream = popen("cat /etc/machine-id", "r");
       fread(buf, sizeof(char), sizeof(buf), rstream);

--- a/linux/flutter_udid_plugin.cc
+++ b/linux/flutter_udid_plugin.cc
@@ -29,9 +29,12 @@ static void flutter_udid_plugin_handle_method_call(
   if (strcmp(method, "getUDID") == 0) {
     FILE *rstream = NULL;
     char buf[1024] = {0};
+    /*
+    // fix: linux permission denied, use /etc/machine-id
     rstream = popen("dmidecode -s system-uuid","r");
     fread(buf, sizeof(char), sizeof(buf), rstream);
     pclose(rstream);
+    */
     if(buf[0] == 0) {
       rstream = popen("cat /etc/machine-id", "r");
       fread(buf, sizeof(char), sizeof(buf), rstream);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_udid
 description: Plugin to retrieve a persistent UDID across reinstalls on iOS and Android
-version: 3.0.0
+version: 4.0.0
 homepage: https://github.com/GigaDroid/flutter_udid
 
 environment:


### PR DESCRIPTION
fix: https://github.com/GigaDroid/flutter_udid/issues/55