### PR TITLE
fix: jcenter removal warning in Gradle v9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
`jcenter` is deprecated and set to be removed in **Gradle v9**. Using `mavenCentral` instead.

fixes #57