### PR TITLE
fix: add keychain dependency

### DIFF
--- a/ios/flutter_udid/Package.swift
+++ b/ios/flutter_udid/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
   products: [
     .library(name: "flutter-udid", targets: ["flutter_udid"])
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", .upToNextMajor(from: "4.2.2")),
+  ],
   targets: [
     .target(
       name: "flutter_udid",
-      dependencies: [],
+      dependencies: [
+        .product(name: "KeychainAccess", package: "KeychainAccess")
+      ],
       resources: []
     )
   ]


### PR DESCRIPTION
This dependency is used but not listed in `Package.swift`, which is necessary for it to compile with SPM.

Fixes #72