### PR TITLE
fix: declare KeychainAccess for macOS SPM target

### DIFF
--- a/macos/flutter_udid/Package.swift
+++ b/macos/flutter_udid/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
   products: [
     .library(name: "flutter-udid", targets: ["flutter_udid"])
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2")
+  ],
   targets: [
     .target(
       name: "flutter_udid",
-      dependencies: [],
+      dependencies: [
+        .product(name: "KeychainAccess", package: "KeychainAccess")
+      ],
       resources: []
     )
   ]


### PR DESCRIPTION
Compling on **macOS** using SPM throws throws this error: `Unable to find module dependency: 'KeychainAccess'`.

https://github.com/GigaDroid/flutter_udid/pull/74 only fixed the issue on iOS.

It would be great to have a release after merging.