### PR TITLE
Fix Apple keychain UDID persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This provides an UDID using the format of the corresponding platform.
 | Windows  | `99A4D301-53F5-11CB-8CA0-9CA39A9E1F01` | BIOS UUID                                                                                                                                       |
 | Linux    | `1124435e065241dcae2241e9caab9a6c` | Machine ID                                                                                                                                      |
 
+### iOS Keychain availability
+
+On iOS, the UDID is stored in Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. This means it is available only after the user has unlocked the device once after reboot, including later background launches while the device is locked. Before the first unlock after reboot, requesting the UDID throws a `PlatformException`.
+
 To get a consistent formatting on all platforms use:
 
 ```

--- a/ios/flutter_udid/Sources/flutter_udid/FlutterUdidPlugin.swift
+++ b/ios/flutter_udid/Sources/flutter_udid/FlutterUdidPlugin.swift
@@ -3,6 +3,8 @@ import UIKit
 import KeychainAccess
 
 public class FlutterUdidPlugin: NSObject, FlutterPlugin {
+  private static let keychainService = "de.gigadroid.flutter_udid"
+  private static let keychainAccount = "udid"
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_udid", binaryMessenger: registrar.messenger())
@@ -20,35 +22,63 @@ public class FlutterUdidPlugin: NSObject, FlutterPlugin {
   }
 
   private func getUniqueDeviceIdentifierAsString(result: FlutterResult) {
-    let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "flutter_udid"
-    let accountName = Bundle.main.bundleIdentifier ?? "com.default.app"
+    let keychain = Keychain(service: FlutterUdidPlugin.keychainService)
+      .synchronizable(false)
+      .accessibility(.afterFirstUnlockThisDeviceOnly)
 
-    // Use KeychainAccess with same structure as original SAMKeychain implementation
-    let keychain = Keychain(service: bundleName).synchronizable(false)
-
-    // Try to read existing UUID from keychain
-    if let applicationUUID = try? keychain.get(accountName), !applicationUUID.isEmpty {
-      result(applicationUUID)
+    do {
+      if let applicationUUID = try keychain.get(FlutterUdidPlugin.keychainAccount), !applicationUUID.isEmpty {
+        result(applicationUUID)
+        return
+      }
+    } catch {
+      result(FlutterError(code: "UNAVAILABLE",
+                         message: "UDID not available",
+                         details: "keychain_get_failed: \(error.localizedDescription)"))
       return
     }
 
-    // Generate new UUID if none exists
+    do {
+      if let migratedUUID = try self.migratedUniqueDeviceIdentifier(keychain: keychain) {
+        result(migratedUUID)
+        return
+      }
+    } catch {
+      result(FlutterError(code: "UNAVAILABLE",
+                         message: "UDID not available",
+                         details: "keychain_migration_failed: \(error.localizedDescription)"))
+      return
+    }
+
     guard let vendorId = UIDevice.current.identifierForVendor?.uuidString else {
       result(FlutterError(code: "UNAVAILABLE",
                          message: "UDID not available",
-                         details: nil))
+                         details: "identifierForVendor returned nil"))
       return
     }
 
-    // Save the new UUID to keychain
     do {
-      try keychain.set(vendorId, key: accountName)
+      try keychain.set(vendorId, key: FlutterUdidPlugin.keychainAccount)
       result(vendorId)
     } catch {
       result(FlutterError(code: "UNAVAILABLE",
                          message: "UDID not available",
-                         details: nil))
+                         details: "keychain_set_failed: \(error.localizedDescription)"))
     }
   }
-}
 
+  private func migratedUniqueDeviceIdentifier(keychain: Keychain) throws -> String? {
+    let legacyService = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "flutter_udid"
+    let legacyAccount = Bundle.main.bundleIdentifier ?? "com.default.app"
+    let legacyKeychain = Keychain(service: legacyService)
+      .synchronizable(false)
+      .accessibility(.afterFirstUnlockThisDeviceOnly)
+
+    guard let legacyUUID = try legacyKeychain.get(legacyAccount), !legacyUUID.isEmpty else {
+      return nil
+    }
+
+    try keychain.set(legacyUUID, key: FlutterUdidPlugin.keychainAccount)
+    return legacyUUID
+  }
+}

--- a/macos/flutter_udid/Sources/flutter_udid/FlutterUdidPlugin.swift
+++ b/macos/flutter_udid/Sources/flutter_udid/FlutterUdidPlugin.swift
@@ -4,6 +4,9 @@ import IOKit
 import KeychainAccess
 
 public class FlutterUdidPlugin: NSObject, FlutterPlugin {
+  private static let keychainService = "de.gigadroid.flutter_udid"
+  private static let keychainAccount = "udid"
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_udid", binaryMessenger: registrar.messenger)
     let instance = FlutterUdidPlugin()
@@ -20,35 +23,62 @@ public class FlutterUdidPlugin: NSObject, FlutterPlugin {
   }
 
   private func getUniqueDeviceIdentifierAsString(result: FlutterResult) {
-    let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "flutter_udid"
-    let accountName = Bundle.main.bundleIdentifier ?? "com.default.app"
+    let keychain = Keychain(service: FlutterUdidPlugin.keychainService)
+      .synchronizable(false)
 
-    // Use KeychainAccess with same structure as iOS implementation
-    let keychain = Keychain(service: bundleName).synchronizable(false)
-
-    // Try to read existing UUID from keychain
-    if let applicationUUID = try? keychain.get(accountName), !applicationUUID.isEmpty {
-      result(applicationUUID)
+    do {
+      if let applicationUUID = try keychain.get(FlutterUdidPlugin.keychainAccount), !applicationUUID.isEmpty {
+        result(applicationUUID)
+        return
+      }
+    } catch {
+      result(FlutterError(code: "UNAVAILABLE",
+                         message: "UDID not available",
+                         details: "keychain_get_failed: \(error.localizedDescription)"))
       return
     }
 
-    // Generate new UUID if none exists
+    do {
+      if let migratedUUID = try self.migratedUniqueDeviceIdentifier(keychain: keychain) {
+        result(migratedUUID)
+        return
+      }
+    } catch {
+      result(FlutterError(code: "UNAVAILABLE",
+                         message: "UDID not available",
+                         details: "keychain_migration_failed: \(error.localizedDescription)"))
+      return
+    }
+
     guard let hardwareUUID = self.hardwareUUID(), !hardwareUUID.isEmpty else {
       result(FlutterError(code: "UNAVAILABLE",
                          message: "UDID not available",
-                         details: nil))
+                         details: "hardwareUUID returned nil or empty"))
       return
     }
 
-    // Save the new UUID to keychain
     do {
-      try keychain.set(hardwareUUID, key: accountName)
+      try keychain.set(hardwareUUID, key: FlutterUdidPlugin.keychainAccount)
       result(hardwareUUID)
     } catch {
       result(FlutterError(code: "UNAVAILABLE",
                          message: "UDID not available",
-                         details: nil))
+                         details: "keychain_set_failed: \(error.localizedDescription)"))
     }
+  }
+
+  private func migratedUniqueDeviceIdentifier(keychain: Keychain) throws -> String? {
+    let legacyService = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "flutter_udid"
+    let legacyAccount = Bundle.main.bundleIdentifier ?? "com.default.app"
+    let legacyKeychain = Keychain(service: legacyService)
+      .synchronizable(false)
+
+    guard let legacyUUID = try legacyKeychain.get(legacyAccount), !legacyUUID.isEmpty else {
+      return nil
+    }
+
+    try keychain.set(legacyUUID, key: FlutterUdidPlugin.keychainAccount)
+    return legacyUUID
   }
 
   private func hardwareUUID() -> String? {


### PR DESCRIPTION
## Summary
- store iOS UDIDs under a fixed Keychain service/account and migrate legacy bundle-derived entries
- set iOS Keychain accessibility to afterFirstUnlockThisDeviceOnly and expose native error details
- apply the same fixed Keychain service/account migration and error details on macOS
- document the iOS first-unlock Keychain availability constraint

## Tests
- flutter test
- flutter analyze
- git diff --check