### PR TITLE
Prepare 4.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.3
+* Store iOS and macOS UDIDs under a fixed Keychain service/account and migrate legacy entries
+* Declare KeychainAccess for the macOS Swift Package Manager target
+* Migrate Android Gradle setup for AGP 9 Kotlin compatibility
+
 ## 4.1.2
 * Update Kotlin version to 2.2.20
 

--- a/README.md
+++ b/README.md
@@ -4,41 +4,65 @@
 
 Plugin to retrieve a persistent UDID across app reinstalls on iOS, Android, Mac, Windows & Linux.
 
-## Getting Started
+## Usage
 
-```
+```dart
 import 'package:flutter_udid/flutter_udid.dart';
+
 String udid = await FlutterUdid.udid;
 ```
 
 This provides an UDID using the format of the corresponding platform.
 
-| Platform | Format                                 | Source                                                                                                                                          |
-|----------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| iOS      | `7946DA4E-8429-423C-B405-B3FC77914E3E` | [identifierForVendor (saved to Keychain for persistence)](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) |
-| Android  | `8af8770a27cfd182`                     | [Settings.Secure.ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)                               |
-| Mac      | `707E990C-D002-520B-ABA6-4216C6D514BF` | [kIOPlatformUUIDKey](https://developer.apple.com/documentation/iokit/kioplatformuuidkey)                                                        |
-| Windows  | `99A4D301-53F5-11CB-8CA0-9CA39A9E1F01` | BIOS UUID                                                                                                                                       |
-| Linux    | `1124435e065241dcae2241e9caab9a6c` | Machine ID                                                                                                                                      |
+## Platform IDs
 
-### iOS Keychain availability
+| Platform | Format | Source |
+| --- | --- | --- |
+| iOS | `7946DA4E-8429-423C-B405-B3FC77914E3E` | [identifierForVendor](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor), saved to Keychain for persistence |
+| Android | `8af8770a27cfd182` | [Settings.Secure.ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID) |
+| Mac | `707E990C-D002-520B-ABA6-4216C6D514BF` | [kIOPlatformUUIDKey](https://developer.apple.com/documentation/iokit/kioplatformuuidkey) |
+| Windows | `99A4D301-53F5-11CB-8CA0-9CA39A9E1F01` | BIOS UUID |
+| Linux | `1124435e065241dcae2241e9caab9a6c` | Machine ID |
 
-On iOS, the UDID is stored in Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. This means it is available only after the user has unlocked the device once after reboot, including later background launches while the device is locked. Before the first unlock after reboot, requesting the UDID throws a `PlatformException`.
+### iOS Keychain Availability
+
+On iOS, the UDID is stored in Keychain with
+`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. This means it is available
+only after the user has unlocked the device once after reboot, including later
+background launches while the device is locked. Before the first unlock after
+reboot, requesting the UDID throws a `PlatformException`.
+
+## Consistent Format
 
 To get a consistent formatting on all platforms use:
 
-```
+```dart
 import 'package:flutter_udid/flutter_udid.dart';
+
 String udid = await FlutterUdid.consistentUdid;
 ```
 
-This will result in an UDID of the following format:  
+This will result in an UDID of the following format:
+
 `984725b6c4f55963cc52fca0f943f9a8060b1c71900d542c79669b6dc718a64b`
 
+## Persistence Notes
+
 The UDID can change after a factory reset!
-Additionally if a device has been updated to Android 8.0 through an OTA and the app is reinstalled the UDID may change as well due to security changes in Android 8.0.
-On rooted and jailbroken devices the ID can be changed, so please take this into account. However, it should not be possible to identify as a different device through random guessing because of the complexity of the ID.
-Furthermore, the UDID may also change if there is a change in the app's signing signature, for both iOS and Android. Ensure that you always use the same digital signature to sign your app.
+
+Additionally, if a device has been updated to Android 8.0 through an OTA and
+the app is reinstalled, the UDID may change as well due to security changes in
+Android 8.0.
+
+On rooted and jailbroken devices the ID can be changed, so please take this
+into account. However, it should not be possible to identify as a different
+device through random guessing because of the complexity of the ID.
+
+Furthermore, the UDID may also change if there is a change in the app's signing
+signature, for both iOS and Android. Ensure that you always use the same digital
+signature to sign your app.
+
+## Flutter Resources
 
 For help getting started with Flutter, view the online
 [documentation](https://flutter.io/).

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.1.3"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_udid
 description: Plugin to retrieve a persistent UDID across reinstalls on iOS and Android
-version: 4.1.2
+version: 4.1.3
 homepage: https://github.com/GigaDroid/flutter_udid
 
 environment:


### PR DESCRIPTION
## Summary
- bump package metadata to 4.1.3
- add changelog notes for the latest Keychain and Android Gradle changes
- reorganize README headings and formatting

## Validation
- git diff --check
- flutter pub get --offline