### PR TITLE
fix(android): resolve compile failures under AGP 9+ and fix namespace typo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,13 +24,16 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+
+def builtInKotlinEnabled = (project.findProperty("android.builtInKotlin") ?: "true").toString().toBoolean()
+
+if (agpMajor < 9 || !builtInKotlinEnabled) {
     apply plugin: 'kotlin-android'
 }
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace 'de.gigadroid.flutterudid'
+        namespace 'de.gigadroid.flutter_udid'
     }
 
     compileSdkVersion flutter.compileSdkVersion
@@ -48,8 +51,10 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+if (agpMajor < 9 || !builtInKotlinEnabled) {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+        }
     }
 }


### PR DESCRIPTION
This pull request addresses two critical build-breaking issues introduced in version 4.1.3 during the migration for AGP 9 compatibility. It ensures the package builds regardless of whether the developer uses the modern `android.builtInKotlin=true` flag or retains the legacy `android.builtInKotlin=false` compatibility workaround.

### Fixed Issues

#### 1. Android Namespace Typo
- **Issue**: The declared namespace was `'de.gigadroid.flutterudid'` (missing the underscore). This mismatched the actual package path `'de.gigadroid.flutter_udid'`, causing compilation failures inside the generated `GeneratedPluginRegistrant.java`.
- **Fix**: Updated the namespace setting to `'de.gigadroid.flutter_udid'`.

#### 2. Guarded Kotlin Compilation with Hybrid Fallback
- **Issue**: The `agpMajor < 9` check unconditionally disabled the legacy `kotlin-android` plugin under AGP 9+. However, if a developer is forced to use the `android.builtInKotlin=false` workaround (e.g., due to other unmigrated plugins in their dependency tree), Kotlin compilation was completely skipped for this library, causing a `cannot find symbol: class FlutterUdidPlugin` error.
- **Fix**: Added a dynamic check to identify whether `builtInKotlin` is active. The legacy `kotlin-android` plugin is now correctly applied if we are either on AGP < 9 OR if `builtInKotlin` is explicitly turned off.

### Testing
- Confirmed that this resolves the Gradle project evaluation failure (`Could not find method kotlin()`) when building on AGP 9+.
- Confirmed that this resolves the Java compilation error (`cannot find symbol: class FlutterUdidPlugin` / `package de.gigadroid.flutter_udid does not exist`) inside `GeneratedPluginRegistrant.java` by restoring the correct namespace with the underscore.
- Verified that the plugin now compiles and builds successfully under both `android.builtInKotlin=true` and `android.builtInKotlin=false` build environments.
- These changes only affect Gradle build-time configurations and do not modify any runtime application logic.

Generated with Gemini.